### PR TITLE
Don't force deleterdn in Net_LDAP2_Entry->update() and Net_LDAP2->move()

### DIFF
--- a/Net/LDAP2.php
+++ b/Net/LDAP2.php
@@ -824,7 +824,7 @@ class Net_LDAP2 extends PEAR
                 if ((Net_LDAP2::errorMessage($error_code) === 'LDAP_OPERATIONS_ERROR') &&
                     ($this->_config['auto_reconnect'])) {
                     // The server has become disconnected before trying the
-                    // operation.  We should try again, possibly with a 
+                    // operation.  We should try again, possibly with a
                     // different server.
                     $this->_link = false;
                     $this->performReconnect();
@@ -1319,10 +1319,11 @@ class Net_LDAP2 extends PEAR
     * @param string|Net_LDAP2_Entry $entry       Entry DN or Entry object
     * @param string                 $newdn       New location
     * @param Net_LDAP2              $target_ldap (optional) Target directory for cross server move; should be passed via reference
+    * @param boolean                $deleteoldrdn (optional) if false the old RDN value(s) is retained as non-distinguishided values of the entry.
     *
     * @return Net_LDAP2_Error|true
     */
-    public function move($entry, $newdn, $target_ldap = null)
+    public function move($entry, $newdn, $target_ldap = null, $deleteoldrdn = true)
     {
         if (is_string($entry)) {
             $entry_o = $this->getEntry($entry);
@@ -1363,7 +1364,7 @@ class Net_LDAP2 extends PEAR
             // local move
             $entry_o->dn($newdn);
             $entry_o->setLDAP($this);
-            return $entry_o->update();
+            return $entry_o->update($deleteoldrdn);
         }
     }
 

--- a/Net/LDAP2/Entry.php
+++ b/Net/LDAP2/Entry.php
@@ -490,7 +490,7 @@ class Net_LDAP2_Entry extends PEAR
                         $value = array_shift($value);
                     }
             }
-            
+
         }
 
         return $value;
@@ -745,13 +745,14 @@ class Net_LDAP2_Entry extends PEAR
     * Remove the entry from the server and readd it as new in such cases.
     * This also will deal with problems with setting structural object classes.
     *
-    * @param Net_LDAP2 $ldap If passed, a call to setLDAP() is issued prior update, thus switching the LDAP-server. This is for perl-ldap interface compliance
+    * @param Net_LDAP2  $ldap If passed, a call to setLDAP() is issued prior update, thus switching the LDAP-server. This is for perl-ldap interface compliance
+    * @param boolean    $deleteoldrdn (optional) if false the old RDN value(s) is retained as non-distinguishided values of the entry.
     *
     * @access public
     * @return true|Net_LDAP2_Error
     * @todo Entry rename with a DN containing special characters needs testing!
     */
-    public function update($ldap = null)
+    public function update($deleteoldrdn = true, $ldap = null)
     {
         if ($ldap) {
             $msg = $this->setLDAP($ldap);
@@ -826,7 +827,7 @@ class Net_LDAP2_Entry extends PEAR
             $parent = Net_LDAP2_Util::canonical_dn($parent);
 
             // rename/move
-            if (false == @ldap_rename($link, $this->_dn, $child, $parent, false)) {
+            if (false == @ldap_rename($link, $this->_dn, $child, $parent, $deleteoldrdn)) {
 
                 return PEAR::raiseError("Entry not renamed: " .
                                         @ldap_error($link), @ldap_errno($link));
@@ -851,8 +852,8 @@ class Net_LDAP2_Entry extends PEAR
             if ($fullEntry->exists($attr)) {
                 $currentValue = $fullEntry->getValue($attr, "all");
                 $value = array_merge( $currentValue, $value );
-            } 
-            
+            }
+
             $modifications[$attr] = $value;
         }
 
@@ -865,7 +866,7 @@ class Net_LDAP2_Entry extends PEAR
             if (!is_array($value)) {
                 $value = array($value);
             }
-            
+
             // Find out what is missing from $value and exclude it
             $currentValue = isset($modifications[$attr]) ? $modifications[$attr] : $fullEntry->getValue($attr, "all");
             $modifications[$attr] = array_values( array_diff( $currentValue, $value ) );


### PR DESCRIPTION
When using 
- update method on Net_LDAP2_Entry or
- move method on Net_LDAP2

the deleteoldrdn parameter of underlying ldap_rename() function is forced to true. Not allways usable depending on the ldap schema.

Already discussed in the PEAR bug #20003 https://pear.php.net/bugs/bug.php?id=20003
