### PR TITLE
Net_LDAP2_Util :: canonical_dn : Fix escaping slashing slashes

### DIFF
--- a/Net/LDAP2/Util.php
+++ b/Net/LDAP2/Util.php
@@ -409,7 +409,7 @@ class Net_LDAP2_Util extends PEAR
 
                     // escaping of dn-value
                     $val = self::escape_dn_value(array($val));
-                    $val = str_replace('/', '\/', $val[0]);
+                    $val = str_replace('/', '\\2f', $val[0]);
 
                     $dn[$pos] = $ocl.'='.$val;
                 }


### PR DESCRIPTION
Hello,

I detect an error in _canonical_dn_ method of the _Net_LDAP2_Util_ class : slashes are escape using a simple backslash but the resulting DN is refuse by OpenLDAP on moving operation.

It's could be easily reproduce by moving an object with a slash in new RDN.

To solve that, I simply change the substitution string to '\\2f' (ASCII Hex format).