### PR TITLE
fix: remove unused $ber property

### DIFF
--- a/Net/LDAP2/Entry.php
+++ b/Net/LDAP2/Entry.php
@@ -363,10 +363,9 @@ class Net_LDAP2_Entry extends PEAR
             $attributes = array();
             do {
                 if (empty($attr)) {
-                    $ber  = null;
-                    $attr = @ldap_first_attribute($this->_link, $this->_entry, $ber);
+                    $attr = @ldap_first_attribute($this->_link, $this->_entry);
                 } else {
-                    $attr = @ldap_next_attribute($this->_link, $this->_entry, $ber);
+                    $attr = @ldap_next_attribute($this->_link, $this->_entry);
                 }
                 if ($attr) {
                     $func = 'ldap_get_values'; // standard function to fetch value


### PR DESCRIPTION
Since PHP v8.0.0 the $ber property is no longer accepted and causes the following error to be thrown:

```
PHP message: PHP Fatal error:  Uncaught ArgumentCountError: ldap_first_attribute() expects exactly 2 arguments, 3 given in /var/www/html/vendor/pear/net_ldap2/Net/LDAP2/Entry.php:367
``` 

See https://www.php.net/manual/en/function.ldap-first-attribute.php