### PR TITLE
Net_LDAP2_Entry::update(): do not submit empty modification

### DIFF
--- a/Net/LDAP2/Entry.php
+++ b/Net/LDAP2/Entry.php
@@ -877,7 +877,7 @@ class Net_LDAP2_Entry extends PEAR
         }
 
         // COMMIT
-        if (false === @ldap_modify($link, $this->dn(), $modifications)) {
+        if ($modifications && false === @ldap_modify($link, $this->dn(), $modifications)) {
             return PEAR::raiseError("Could not modify the entry: " . @ldap_error($link), @ldap_errno($link));
         }
 


### PR DESCRIPTION
Fix #9 